### PR TITLE
RO-2450: Ikke parse json-property

### DIFF
--- a/src/components/varsom-observation/varsom-observation.tsx
+++ b/src/components/varsom-observation/varsom-observation.tsx
@@ -109,7 +109,7 @@ export class VarsomObservation {
   let geoHazardId = getGeoHazardIdFromName(this.type);
   let langKey = getLangKeyFromName(getLocaleFromDom(this.elem));
   let _data; 
-  if (!(this.json && this.json.length > 2)){
+  if (!(this.json)){
   if (this.regid.length !== 0){
     _data = `{"LangKey": ${langKey}, "RegId": ${this.regid}}`
   } else
@@ -124,7 +124,7 @@ export class VarsomObservation {
   data = await response.json();
   
 }else {
-  data = JSON.parse(this.json);
+  data = [this.json];
 }
 
      for(let i = 0; i < this.count; i++){

--- a/src/index.html
+++ b/src/index.html
@@ -20,4 +20,131 @@
   </head>
   <body>
 
-    <varsom-observation version="" type="Dirt" regid="338719" count=1></varsom-observation>    
+    <varsom-observation id="obs"></varsom-observation>
+
+    <script>
+      const observation = {
+        "RegId": 352505,
+        "ExternalReferenceId": "7d157228-83fe-4fd0-8b88-4ec03a6aaaa5",
+        "GeoHazardName": "Snø",
+        "DtRegTime": "2023-08-28T10:38:20+00:00",
+        "DtChangeTime": "2023-08-28T10:38:20+00:00",
+        "SourceName": "Ikke gitt",
+        "Observer": {
+          "NickName": "Pincus",
+          "ObserverID": 48616,
+          "CompetenceLevelTID": 0,
+          "CompetenceLevelName": "Ukjent"
+        },
+        "ObsLocation": {
+          "ForecastRegionTID": 3045,
+          "ForecastRegionName": "Oslo",
+          "Height": 28,
+          "MunicipalName": "OSLO",
+          "MunicipalNo": "0301",
+          "CountryId": 578,
+          "CountryName": "Norge",
+          "UTMSourceName": "Klikk i kart i regObs-app",
+          "Title": "Oslo / OSLO",
+          "ObsLocationID": 216309,
+          "LocationName": null,
+          "LocationDescription": "Oslo",
+          "Latitude": 59.9200972441,
+          "Longitude": 10.7384490967,
+          "UTMSourceTID": 35,
+          "Uncertainty": null
+        },
+        "Attachments": [],
+        "AvalancheActivityObs2": [],
+        "AvalancheEvalProblem2": [],
+        "AvalancheEvaluation3": null,
+        "AvalancheObs": null,
+        "CompressionTest": [],
+        "DangerObs": [
+          {
+            "GeoHazardName": "Snø",
+            "DangerSignName": "Ferske skred",
+            "GeoHazardTID": 10,
+            "DangerSignTID": 2,
+            "Comment": null
+          }
+        ],
+        "GeneralObservation": null,
+        "IceCoverObs": null,
+        "IceThickness": null,
+        "Incident": null,
+        "LandSlideObs": null,
+        "SnowProfile2": null,
+        "SnowSurfaceObservation": {
+          "SnowWindDepth24": null,
+          "SurfaceWaterContentName": "Ikke observert",
+          "SnowDriftName": "Ikke observert",
+          "SnowSurfaceName": "Ikke observert",
+          "SkiConditionsTID": null,
+          "SkiConditionsName": null,
+          "SurfaceRougnessTID": 0,
+          "SurfaceRougnessName": "Ikke observert",
+          "FootPenetration": null,
+          "SnowDepth": null,
+          "NewSnowDepth24": null,
+          "NewSnowLine": null,
+          "SurfaceWaterContentTID": 0,
+          "SnowDriftTID": 0,
+          "SnowSurfaceTID": 0,
+          "Comment": null,
+          "HeightLimitLayeredSnow": null,
+          "SnowLine": null
+        },
+        "WeatherObservation": null,
+        "WaterLevel2": null,
+        "DamageObs": [],
+        "Summaries": [
+          {
+            "RegistrationTID": 13,
+            "RegistrationName": "Faretegn",
+            "AdaptiveElements": [
+              {
+                "type": "FactSet",
+                "facts": [
+                  {
+                    "title": "Type",
+                    "value": "Ferske skred"
+                  }
+                ]
+              }
+            ],
+            "Summaries": [
+              {
+                "Kind": 1,
+                "KindType": "Text",
+                "Header": "Type",
+                "Value": "Ferske skred"
+              }
+            ]
+          },
+          {
+            "RegistrationTID": 22,
+            "RegistrationName": "Snødekke",
+            "AdaptiveElements": [],
+            "Summaries": []
+          }
+        ],
+        "AttachmentSummaries": [],
+        "SnowProfile": null,
+        "AvalancheEvaluation": null,
+        "AvalancheActivityObs": null,
+        "AvalancheDangerObs": [],
+        "AvalancheEvalProblem": [],
+        "AvalancheEvaluation2": null,
+        "SnowCoverObs": null,
+        "WaterLevel": null,
+        "GeoHazardTID": 10,
+        "SourceTID": 0,
+        "DtObsTime": "2023-08-28T12:37:41+02:00",
+        "ObserverGroupID": null,
+        "ObserverGroupName": null,
+        "Anonymous": false
+      };
+      document.querySelector("#obs").json = observation;
+    </script>
+  </body>


### PR DESCRIPTION
Når man bruker json-propertien er den allerede json, den trenger ikke parses.
Denne endringen fikser det, men forutsetter fiksen at man bare sender inn ett enkelt json-objekt. Det støttes ikke å sende inn flere objekter på en gang.